### PR TITLE
update code block styling

### DIFF
--- a/docs/sylesheets/extra.css
+++ b/docs/sylesheets/extra.css
@@ -151,7 +151,6 @@ code {
   padding: 0.15em 0.4em;
   border-radius: 0.25rem;
   box-shadow: inset 0 0 0.05rem rgba(46, 52, 64, 0.2);
-  white-space: nowrap;
 }
 
 /* Code block container */


### PR DESCRIPTION
This change removed the `nowrap` option as it was causing an extra white space at the end of code when you tripple clicked to select.